### PR TITLE
bumping SDK version to 0.6.0, and bumping API version to 0.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cript
-version = 0.5.0
+version = 0.6.0
 description = CRIPT Python SDK
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/cript/__init__.py
+++ b/src/cript/__init__.py
@@ -14,7 +14,7 @@ pint.util.logger.setLevel(logging.ERROR)  # Mute Pint warnings
 __version__ = importlib.metadata.version("cript")
 __short_version__ = __version__.rpartition(".")[0]
 
-__api_version__ = "0.5.0"
+__api_version__ = "0.6.0"
 
 # Instantiate the Pint unit registry
 # https://pint.readthedocs.io/en/stable/tutorial.html#using-pint-in-your-projects


### PR DESCRIPTION
bumping SDK version to 0.6.0 because of breaking changes
bumped API version to 0.6.0 because that is the version of the API that the SDK can talk to