### PR TITLE
storage code error

### DIFF
--- a/src/cript/storage_clients/exceptions.py
+++ b/src/cript/storage_clients/exceptions.py
@@ -1,6 +1,18 @@
 from cript.exceptions import CRIPTError
 
 
+class InvalidAuthCode(CRIPTError):
+    """
+    Raised when an Authentication code to connect to a storage client is invalid
+    """
+
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "Unable to authenticate with storage client. Please use a valid authentication code"
+
+
 class FileUploadError(CRIPTError):
     """Raised when a file upload fails."""
 

--- a/src/cript/storage_clients/globus.py
+++ b/src/cript/storage_clients/globus.py
@@ -6,7 +6,7 @@ import globus_sdk
 from globus_sdk.scopes import ScopeBuilder
 
 from cript.data_model.nodes.base_node import BaseNode
-from .exceptions import InvalidAuthCode, FileUploadError, FileDownloadError
+from cript.storage_clients.exceptions import InvalidAuthCode, FileUploadError, FileDownloadError
 
 
 logger = getLogger(__name__)

--- a/src/cript/storage_clients/globus.py
+++ b/src/cript/storage_clients/globus.py
@@ -6,8 +6,7 @@ import globus_sdk
 from globus_sdk.scopes import ScopeBuilder
 
 from cript.data_model.nodes.base_node import BaseNode
-from cript.storage_clients.exceptions import FileUploadError
-from cript.storage_clients.exceptions import FileDownloadError
+from .exceptions import InvalidAuthCode, FileUploadError, FileDownloadError
 
 
 logger = getLogger(__name__)
@@ -154,7 +153,11 @@ class GlobusClient:
             auth_code = input("Enter the code here: ").strip()
 
         # Get tokens
-        token_response = self.auth_client.oauth2_exchange_code_for_tokens(auth_code)
+        try:
+            token_response = self.auth_client.oauth2_exchange_code_for_tokens(auth_code)
+        except globus_sdk.services.auth.errors.AuthAPIError as error:
+            raise InvalidAuthCode
+
         auth_data = token_response.by_resource_server["auth.globus.org"]
         transfer_data = token_response.by_resource_server["transfer.api.globus.org"]
         https_transfer_data = token_response.by_resource_server[self.endpoint_id]


### PR DESCRIPTION
# Issue
Link to issue card: [Raise CRIPT exception for invalid Globus tokens](https://trello.com/c/2VrnZpk1)

# Changes
A custom Exception was written and added to _src/cript/storage_clients/exceptions.py_ that can be raised whenever a user is trying to connect to a storage client (Globus, S3) and gives an invalid authentication code. The error here is more helpful and understandable

## Code
InvalidAuthCode in **storage_clients/exceptions.py**:

```python
class InvalidAuthCode(CRIPTError):
    """
    Raised when an Authentication code to connect to a storage client is invalid
    """

    def __init__(self):
        pass

    def __str__(self):
        return "Unable to authenticate with storage client. Please use a valid authentication code"
```

---

The exception was implemented in **src/cript/storage_clients/globus.py** within a try except block

``` python
from cript.storage_clients.exceptions import InvalidAuthCode, FileUploadError, FileDownloadError

        try:
            token_response = self.auth_client.oauth2_exchange_code_for_tokens(auth_code)
        except globus_sdk.services.auth.errors.AuthAPIError as error:
            raise InvalidAuthCode
```

## Limitations
I have implemented the Exception for Globus storage only.

## Before
When a user would give an invalid authentication code here is the error they would get in the terminal

``` bash
....
File "C:\Users\navid\OneDrive\Desktop\MIT\cript-SDK\src\cript\storage_clients\globus.py", line 157, in set_tokens
    token_response = self.auth_client.oauth2_exchange_code_for_tokens(auth_code)
  File "C:\Users\navid\OneDrive\Desktop\MIT\cript-excel-uploader\venv\lib\site-packages\globus_sdk\services\auth\client\base.py", line 245, in oauth2_exchange_code_for_tokens
    return self.current_oauth2_flow_manager.exchange_code_for_tokens(auth_code)
  File "C:\Users\navid\OneDrive\Desktop\MIT\cript-excel-uploader\venv\lib\site-packages\globus_sdk\services\auth\flow_managers\native_app.py", line 213, in exchange_code_for_tokens
    return self.auth_client.oauth2_token(
  File "C:\Users\navid\OneDrive\Desktop\MIT\cript-excel-uploader\venv\lib\site-packages\globus_sdk\services\auth\client\base.py", line 453, in oauth2_token
    self.post(
  File "C:\Users\navid\OneDrive\Desktop\MIT\cript-excel-uploader\venv\lib\site-packages\globus_sdk\client.py", line 155, in post
    return self.request(
  File "C:\Users\navid\OneDrive\Desktop\MIT\cript-excel-uploader\venv\lib\site-packages\globus_sdk\client.py", line 310, in request
    raise self.error_class(r)
globus_sdk.services.auth.errors.AuthAPIError: ('POST', 'https://auth.globus.org/v2/oauth2/token', None, 400, 'Error', '{"error":"invalid_grant"}')
```

## After
With the new Exception here is the error the users would get when they input an invalid authentication code for Globus

``` bash
....
File "C:\Users\navid\OneDrive\Desktop\MIT\cript-SDK\src\cript\storage_clients\globus.py", line 160, in set_tokens
    raise InvalidAuthCode
cript.storage_clients.exceptions.InvalidAuthCode: Unable to authenticate with storage client. Please use a valid Authentication code
```

# Tests
I manually tested this with the Excel Uploader because that uses the SDK under the hood. I installed the SDK in edit mode `pip install -e ..\cript-SDK\` and when I got to the Globus Authentication code screen I would enter an invalid authentication code and get the errors in the terminal