### PR TITLE
Improve UniqueNodeError for usability

### DIFF
--- a/src/cript/api/rest.py
+++ b/src/cript/api/rest.py
@@ -56,7 +56,9 @@ class API(APIBase):
         try:
             response = self.session.get(f"{self.url}/session-info/")
         except Exception as e:
-            raise APIError("Connection API failed, please review your host and token") from e
+            raise APIError(
+                "Connection API failed, please review your host and token"
+            ) from e
         if response.status_code == 200:
             response_json = response.json()
             self.latest_api_version = response_json["latest_version"]

--- a/src/cript/data_model/exceptions.py
+++ b/src/cript/data_model/exceptions.py
@@ -1,3 +1,5 @@
+import re
+import warnings
 from cript.exceptions import CRIPTError
 
 
@@ -9,6 +11,24 @@ class UniqueNodeError(CRIPTError):
 
     def __init__(self, message):
         self.message = message
+        self.existing_url = None
+        url_find_pattern = (
+            r"[(https://)|\w]*?[\w]*\.[-/\w]*\.\w*[(/{1})]?[#-\./\w]*[(/{1,})]?"
+        )
+        all_urls = re.findall(url_find_pattern, message)
+        if len(all_urls) > 0:
+            if len(all_urls) > 1:
+                warning.warn(
+                    "UniqueNodeError found more than one possible URL of a unique node. Please report this bug here: https://github.com/C-Accel-CRIPT/cript/issues Thank you."
+                )
+            self.existing_url = all_urls[0]
+            while self.existing_url[-1] == ".":
+                self.existing_url = self.existing_url[:-1]
+
+        if self.existing_url is None:
+            warnings.warn(
+                "UniqueNodeError failed to extract unique URL of existing node, please report this bug here: https://github.com/C-Accel-CRIPT/cript/issues Thank you."
+            )
 
     def __str__(self):
         return self.message

--- a/src/cript/storage_clients/globus.py
+++ b/src/cript/storage_clients/globus.py
@@ -6,7 +6,11 @@ import globus_sdk
 from globus_sdk.scopes import ScopeBuilder
 
 from cript.data_model.nodes.base_node import BaseNode
-from cript.storage_clients.exceptions import InvalidAuthCode, FileUploadError, FileDownloadError
+from cript.storage_clients.exceptions import (
+    InvalidAuthCode,
+    FileUploadError,
+    FileDownloadError,
+)
 
 
 logger = getLogger(__name__)


### PR DESCRIPTION
A common situation for my developing with the SDK that, I don't know if a node exists or not.

For example, a script that adds a Material to a collection, might create the collection first, but with the second material that the `Collection` node exists already.
Or citing a paper, a different user might have added the reference already.

For these situations it would be nice to catch the exception and fetch the existing node instead.
(Or course, this has to be used with a bit of care to not overwrite or use false duplicate nodes.)

So this would be ideal:

```python
try:
       ref = cript.Reference(title="Title, doi="10.1039/D2ME00137C",  authors=["Schneider, Ludwig"])
except  cript.data_model.exceptions.UniqueNodeError as exc:
      ref = cript.Reference.get(exc.existing_url)
```

This requires that the `UniqueNodeError` transparently makes the found url accessible.
In this PR, I simply parse the URL from the message and make it available.

As a precaution for changing message, I issue warnings if no such URL can be found.

