### PR TITLE
patching create node issue within the utils.py

### DIFF
--- a/src/cript/data_model/utils.py
+++ b/src/cript/data_model/utils.py
@@ -38,6 +38,9 @@ def create_node(node_class, obj_json):
     created_at = obj_json.pop("created_at")
     updated_at = obj_json.pop("updated_at")
 
+    # pop unused key for Python SDK, but used in web SDK
+    obj_json.pop("can_edit", None)
+
     # Create node
     node = node_class(**obj_json)
 


### PR DESCRIPTION
Discovered this issue with the new API on staging and develop servers. API gives back a "can_edit" filed within the JSON, but that is not used for python SDK or the Excel Uploader but is used in the Web SDK for criptapp