### PR TITLE
bumped SDK version to 0.6.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cript
-version = 0.6.2
+version = 0.6.3
 description = CRIPT Python SDK
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Description
Bump version from 0.6.2 to 0.6.3 for the [newest patch](https://github.com/C-Accel-CRIPT/cript/pull/88) and getting ready for release to Pypi